### PR TITLE
Update code for 1.21.10 support

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,6 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="21 (2)" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -19,7 +19,7 @@
     <remote-repository>
       <option name="id" value="LoomGlobalMinecraft" />
       <option name="name" value="LoomGlobalMinecraft" />
-      <option name="url" value="file:/$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/fabric-loom/minecraftMaven/" />
+      <option name="url" value="file:/$PROJECT_DIR$/../scoop/apps/gradle/current/.gradle/caches/fabric-loom/minecraftMaven/" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="LoomLocalMinecraft" />
@@ -64,7 +64,7 @@
     <remote-repository>
       <option name="id" value="LoomGlobalMinecraft" />
       <option name="name" value="LoomGlobalMinecraft" />
-      <option name="url" value="file:/$USER_HOME$/.gradle/caches/fabric-loom/minecraftMaven/" />
+      <option name="url" value="file:/$PROJECT_DIR$/../.gradle/caches/fabric-loom/minecraftMaven/" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="Terraformers" />
@@ -80,6 +80,26 @@
       <option name="id" value="maven" />
       <option name="name" value="maven" />
       <option name="url" value="https://repo.znotchill.me/repository/maven-releases/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="LoomLocalRemappedMods" />
+      <option name="name" value="LoomLocalRemappedMods" />
+      <option name="url" value="file:$PROJECT_DIR$/.gradle/loom-cache/remapped_mods/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="LoomGlobalMinecraft" />
+      <option name="name" value="LoomGlobalMinecraft" />
+      <option name="url" value="file:$PROJECT_DIR$/../.gradle/caches/fabric-loom/minecraftMaven/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="LoomLocalMinecraft" />
+      <option name="name" value="LoomLocalMinecraft" />
+      <option name="url" value="file:$PROJECT_DIR$/.gradle/loom-cache/minecraftMaven/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenLocal" />
+      <option name="name" value="MavenLocal" />
+      <option name="url" value="file:$MAVEN_REPOSITORY$/" />
     </remote-repository>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,6 +12,9 @@
     <option name="customApplicationId" value="" />
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21 (2)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,9 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/mod/alyx.marmot.mod.client.iml" filepath="$PROJECT_DIR$/.idea/modules/mod/alyx.marmot.mod.client.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/mod/alyx.marmot.mod.main.iml" filepath="$PROJECT_DIR$/.idea/modules/mod/alyx.marmot.mod.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/mod/alyx.marmot.mod.test.iml" filepath="$PROJECT_DIR$/.idea/modules/mod/alyx.marmot.mod.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/common/marmot.common.main.iml" filepath="$PROJECT_DIR$/.idea/modules/common/marmot.common.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/common/marmot.common.test.iml" filepath="$PROJECT_DIR$/.idea/modules/common/marmot.common.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/mod/marmot.mod.client.iml" filepath="$PROJECT_DIR$/.idea/modules/mod/marmot.mod.client.iml" />
@@ -11,9 +14,13 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/servers/minestom/marmot.servers.minestom.test.iml" filepath="$PROJECT_DIR$/.idea/modules/servers/minestom/marmot.servers.minestom.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/servers/paper/marmot.servers.paper.main.iml" filepath="$PROJECT_DIR$/.idea/modules/servers/paper/marmot.servers.paper.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/servers/paper/marmot.servers.paper.test.iml" filepath="$PROJECT_DIR$/.idea/modules/servers/paper/marmot.servers.paper.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/common/me.znotchill.marmot.marmot.common.main.iml" filepath="$PROJECT_DIR$/.idea/modules/common/me.znotchill.marmot.marmot.common.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/common/me.znotchill.marmot.marmot.common.test.iml" filepath="$PROJECT_DIR$/.idea/modules/common/me.znotchill.marmot.marmot.common.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/mod/me.znotchill.marmot.marmot.mod.client.iml" filepath="$PROJECT_DIR$/.idea/modules/mod/me.znotchill.marmot.marmot.mod.client.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/mod/me.znotchill.marmot.marmot.mod.main.iml" filepath="$PROJECT_DIR$/.idea/modules/mod/me.znotchill.marmot.marmot.mod.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/mod/me.znotchill.marmot.marmot.mod.test.iml" filepath="$PROJECT_DIR$/.idea/modules/mod/me.znotchill.marmot.marmot.mod.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/servers/paper/me.znotchill.marmot.marmot.servers.paper.main.iml" filepath="$PROJECT_DIR$/.idea/modules/servers/paper/me.znotchill.marmot.marmot.servers.paper.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/servers/paper/me.znotchill.marmot.marmot.servers.paper.test.iml" filepath="$PROJECT_DIR$/.idea/modules/servers/paper/me.znotchill.marmot.marmot.servers.paper.test.iml" />
     </modules>
   </component>
 </project>

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,9 +5,9 @@ mod_version=1.2.15
 common_version=1.2.13
 
 # Client-side mod
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
-loader_version=0.17.2
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
+loader_version=0.17.3
 kotlin_loader_version=1.13.6+kotlin.2.2.20
 
 maven_group=me.znotchill.marmot

--- a/mod/src/client/kotlin/me/znotchill/marmot/client/packets/clientbound/handlers/ForceKeybindsHandler.kt
+++ b/mod/src/client/kotlin/me/znotchill/marmot/client/packets/clientbound/handlers/ForceKeybindsHandler.kt
@@ -17,7 +17,7 @@ class ForceKeybindsHandler {
             client.execute {
                 payload.binds.forEach { (bindName, forcedKeyTranslationKey) ->
                     try {
-                        client.options.allKeys.firstOrNull { it.translationKey == bindName }
+                        client.options.allKeys.firstOrNull { it.boundKeyTranslationKey == bindName }
                         InputUtil.fromTranslationKey(forcedKeyTranslationKey)
                     } catch (e: NumberFormatException) {
                         MarmotClient.LOGGER.error("Server sent an invalid keybind! $bindName -> $forcedKeyTranslationKey")
@@ -43,7 +43,7 @@ class ForceKeybindsHandler {
     fun onKeybindsAccept(payload: ForceKeybindsPayload, context: ClientPlayNetworking.Context) {
         val client = context.client()
         payload.binds.forEach { (bindName, forcedKeyTranslationKey) ->
-            val keyBinding = client.options.allKeys.firstOrNull { it.translationKey == bindName }
+            val keyBinding = client.options.allKeys.firstOrNull { it.boundKeyTranslationKey == bindName }
                 ?: return@forEach println("Unknown bind name: $bindName")
 
             val forcedKey = InputUtil.fromTranslationKey(forcedKeyTranslationKey)
@@ -51,7 +51,7 @@ class ForceKeybindsHandler {
 
             println("RECEIVED KEYBIND $keyBinding -> $forcedKey")
             KeybindManager.overrideKeybind(keyBinding, forcedKey)
-            println("Set ${keyBinding.translationKey} to $forcedKeyTranslationKey")
+            println("Set ${keyBinding.boundKeyTranslationKey} to $forcedKeyTranslationKey")
         }
 
         KeyBinding.updateKeysByCode()

--- a/mod/src/client/kotlin/me/znotchill/marmot/client/ui/screens/ForceKeybindsScreen.kt
+++ b/mod/src/client/kotlin/me/znotchill/marmot/client/ui/screens/ForceKeybindsScreen.kt
@@ -37,7 +37,7 @@ class ForceKeybindsScreen(
             rowHeight
         )
         payload.binds.forEach { (bindName, keyString) ->
-            val keyBinding = client!!.options.allKeys.firstOrNull { it.translationKey.endsWith(bindName) }
+            val keyBinding = client!!.options.allKeys.firstOrNull { it.boundKeyTranslationKey.endsWith(bindName) }
             if (keyBinding != null) {
                 keybindList.addKeybind(keyBinding, keyString)
             }
@@ -93,15 +93,20 @@ class ForceKeybindsScreen(
 
         inner class KeybindEntry(val bind: KeyBinding, val key: String) : Entry<KeybindEntry>() {
             override fun render(
-                context: DrawContext, index: Int, y: Int, x: Int,
-                entryWidth: Int, entryHeight: Int, mouseX: Int, mouseY: Int,
-                hovered: Boolean, tickDelta: Float
+                context: DrawContext?,
+                mouseX: Int,
+                mouseY: Int,
+                hovered: Boolean,
+                deltaTicks: Float
             ) {
                 try {
                     val fontHeight = textRenderer.fontHeight
                     val padding = 5
+                    // @TODO test
+                    val entryWidth = width - padding * 2
+                    val entryHeight = height + padding * 2
 
-                    val bindText = Text.translatable(bind.translationKey)
+                    val bindText = Text.translatable(bind.boundKeyTranslationKey)
 
                     val keyText = InputUtil.fromTranslationKey(key)?.localizedText
                         ?: Text.literal(key)
@@ -112,9 +117,9 @@ class ForceKeybindsScreen(
                     val keyX = x + entryWidth - keyWidth - 5
                     val keyY = y + (entryHeight - keyHeight) / 2
 
-                    context.fill(keyX, keyY, keyX + keyWidth, keyY + keyHeight, 0xFF555555.toInt())
+                    context?.fill(keyX, keyY, keyX + keyWidth, keyY + keyHeight, 0xFF555555.toInt())
 
-                    context.drawText(
+                    context?.drawText(
                         textRenderer,
                         keyText,
                         keyX + (keyWidth - textRenderer.getWidth(keyText)) / 2,
@@ -123,7 +128,7 @@ class ForceKeybindsScreen(
                         false
                     )
 
-                    context.drawText(
+                    context?.drawText(
                         textRenderer,
                         bindText,
                         x + 5,
@@ -132,11 +137,12 @@ class ForceKeybindsScreen(
                         false
                     )
                 } catch (e: NumberFormatException) {
-                    MarmotClient.LOGGER.error("Server sent an invalid keybind! ${bind.translationKey} -> $key")
+                    MarmotClient.LOGGER.error("Server sent an invalid keybind! ${bind.boundKeyTranslationKey} -> $key")
                 } catch (e: Exception) {
                     e.printStackTrace()
                 }
             }
+
         }
     }
 }


### PR DESCRIPTION
- Updated all instances of `translationKey` to `boundKeyTranslationKey`
- Create new `entryWidth` and `entryHeight` for keybind renderer due to signature changes
```kotlin
// @TODO test
val entryWidth = width - padding * 2
val entryHeight = height + padding * 2
```
This portion of the code is untested, should work mathematically, but untested

This compiles, although is untested